### PR TITLE
use shellwords to escape args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.nyc_output
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+circle.yml
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "4.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-heroku-run
+heroku-run [![Circle CI](https://circleci.com/gh/heroku/heroku-run.svg?style=svg)](https://circleci.com/gh/heroku/heroku-run)
 ==========
 
-[![Circle CI](https://circleci.com/gh/heroku/heroku-run.svg?style=svg)](https://circleci.com/gh/heroku/heroku-run)
+[![codecov](https://codecov.io/gh/heroku/heroku-run/branch/master/graph/badge.svg)](https://codecov.io/gh/heroku/heroku-run)
 [![License](https://img.shields.io/github/license/heroku/heroku-run.svg)](https://github.com/heroku/heroku-run/blob/master/LICENSE)
 
 Heroku CLI plugin to run one-off dyno processes.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 heroku-run
 ==========
 
-[![Build Status](https://travis-ci.org/heroku/heroku-run.svg?branch=master)](https://travis-ci.org/heroku/heroku-run)
+[![Circle CI](https://circleci.com/gh/heroku/heroku-run.svg?style=svg)](https://circleci.com/gh/heroku/heroku-run)
 [![License](https://img.shields.io/github/license/heroku/heroku-run.svg)](https://github.com/heroku/heroku-run/blob/master/LICENSE)
 
 Heroku CLI plugin to run one-off dyno processes.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  node:
+    version: v5.10.1
+test:
+  post:
+    - npm run coverage

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,12 @@
+---
 machine:
   node:
-    version: v5.10.1
+    version: v6.2.0
 test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
+  override:
+    - MOCHA_FILE=$CIRCLE_TEST_REPORTS/mocha/results.xml nyc mocha test -R mocha-junit-reporter
+    - standard
   post:
-    - npm run coverage
+    - nyc report --reporter=text-lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict'
 
-let cli = require('heroku-cli-util')
+const cli = require('heroku-cli-util')
+const shellwords = require('shellwords')
 
 function buildCommand (args) {
   if (args.length === 1) {
@@ -8,14 +9,7 @@ function buildCommand (args) {
     // `heroku run "rake test"` should work like `heroku run rake test`
     return args[0]
   }
-  let cmd = ''
-  for (let arg of args) {
-    if (arg.indexOf(' ') !== -1) {
-      arg = `"${arg}"`
-    }
-    cmd = cmd + ' ' + arg
-  }
-  return cmd.trim()
+  return args.map(shellwords.escape).join(' ')
 }
 
 function buildEnvFromFlag (flag) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "mocha": "2.4.5",
+    "mocha-junit-reporter": "1.11.1",
     "nock": "8.0.0",
     "nyc": "6.4.4",
     "standard": "7.1.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Heroku CLI plugin to run one-off dyno processes.",
   "main": "index.js",
   "scripts": {
-    "test": "standard",
+    "test": "nyc mocha && standard",
     "preversion": "npm test",
     "postversion": "npm publish && git push && git push --tags"
   },
@@ -23,9 +23,14 @@
   "homepage": "https://github.com/heroku/heroku-run",
   "dependencies": {
     "co": "4.6.0",
-    "heroku-cli-util": "5.10.10"
+    "heroku-cli-util": "5.10.11",
+    "shellwords": "0.1.0",
+    "unexpected": "10.13.2"
   },
   "devDependencies": {
+    "mocha": "2.4.5",
+    "nock": "8.0.0",
+    "nyc": "6.4.4",
     "standard": "7.1.0"
   }
 }

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+cli.raiseErrors = true
+
+const nock = require('nock')
+nock.disableNetConnect()
+
+global.commands = require('../index').commands

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,0 +1,19 @@
+'use strict'
+/* globals describe it */
+
+const helpers = require('../../lib/helpers')
+const expect = require('unexpected')
+
+describe('helpers.buildCommand()', () => {
+  [
+    {args: ['echo foo'], expected: 'echo foo'},
+    {args: ['echo', 'foo bar'], expected: 'echo foo\\ bar'},
+    {args: ['echo', 'foo', 'bar'], expected: 'echo foo bar'},
+    {args: ['echo', '{"foo": "bar"}'], expected: 'echo \\{\\"foo\\":\\ \\"bar\\"\\}'},
+    {args: ['echo', '{"foo":"bar"}'], expected: 'echo \\{\\"foo\\":\\"bar\\"\\}'}
+  ].forEach(example => {
+    it(`parses \`${example.args.join(' ')}\` as ${example.expected}`, () => {
+      expect(helpers.buildCommand(example.args), 'to equal', example.expected)
+    })
+  })
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--require ./test/init.js
+--recursive


### PR DESCRIPTION
this works a bit differently than before, instead of adding quotes around arguments with spaces, it just escapes all the arguments with `shellwords.escape()`. I think this should work in all cases, but it's a little less pretty though if you just have spaces in an argument.

This is intended to fix an issue @dzuelke had trying to run a command like this:

```bash
$ heroku run vendor/bin/wp option add tantan_wordpress_s3 --format=json '{"domain":"path","copy-to-s3":"1","serve-from-s3":"1","ssl":"request"}'
```

Depends on #9

cc @ransombriggs