### PR TITLE
Revert use shellwords to escape args and fix

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const cli = require('heroku-cli-util')
-const shellwords = require('shellwords')
+let cli = require('heroku-cli-util')
 
 function buildCommand (args) {
   if (args.length === 1) {
@@ -9,7 +8,14 @@ function buildCommand (args) {
     // `heroku run "rake test"` should work like `heroku run rake test`
     return args[0]
   }
-  return args.map(shellwords.escape).join(' ')
+  let cmd = ''
+  for (let arg of args) {
+    if (arg.indexOf(' ') !== -1 || arg.indexOf('"') !== -1) {
+      arg = '"' + arg.replace(/"/g, '\\"') + '"'
+    }
+    cmd = cmd + ' ' + arg
+  }
+  return cmd.trim()
 }
 
 function buildEnvFromFlag (flag) {

--- a/test/commands/run.js
+++ b/test/commands/run.js
@@ -22,7 +22,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['echo', '{"foo": "bar"}']})
+    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"}']})
     .then(() => fixture.release())
     .then(() => expect(stdout, 'to equal', '{"foo": "bar"}\n'))
   })
@@ -31,7 +31,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['echo', '{"foo":"bar"}']})
+    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
     .then(() => fixture.release())
     .then(() => expect(stdout, 'to equal', '{"foo":"bar"}\n'))
   })

--- a/test/commands/run.js
+++ b/test/commands/run.js
@@ -18,6 +18,24 @@ describe('run', () => {
     .then(() => expect(stdout, 'to equal', '1 2 3\n'))
   })
 
+  it('runs a command with spaces', () => {
+    let stdout = ''
+    let fixture = new StdOutFixture()
+    fixture.capture(s => { stdout += s })
+    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['echo', '{"foo": "bar"}']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout, 'to equal', '{"foo": "bar"}\n'))
+  })
+
+  it('runs a command with quotes', () => {
+    let stdout = ''
+    let fixture = new StdOutFixture()
+    fixture.capture(s => { stdout += s })
+    return cmd.run({app: 'heroku-run-test-app', flags: {}, auth: {password: apikey}, args: ['echo', '{"foo":"bar"}']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout, 'to equal', '{"foo":"bar"}\n'))
+  })
+
   it('runs a command with env vars', () => {
     let stdout = ''
     let fixture = new StdOutFixture()

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -7,10 +7,10 @@ const expect = require('unexpected')
 describe('helpers.buildCommand()', () => {
   [
     {args: ['echo foo'], expected: 'echo foo'},
-    {args: ['echo', 'foo bar'], expected: 'echo foo\\ bar'},
+    {args: ['echo', 'foo bar'], expected: 'echo "foo bar"'},
     {args: ['echo', 'foo', 'bar'], expected: 'echo foo bar'},
-    {args: ['echo', '{"foo": "bar"}'], expected: 'echo \\{\\"foo\\":\\ \\"bar\\"\\}'},
-    {args: ['echo', '{"foo":"bar"}'], expected: 'echo \\{\\"foo\\":\\"bar\\"\\}'}
+    {args: ['echo', '{"foo": "bar"}'], expected: 'echo "{\\"foo\\": \\"bar\\"}"'},
+    {args: ['echo', '{"foo":"bar"}'], expected: 'echo "{\\"foo\\":\\"bar\\"}"'}
   ].forEach(example => {
     it(`parses \`${example.args.join(' ')}\` as ${example.expected}`, () => {
       expect(helpers.buildCommand(example.args), 'to equal', example.expected)


### PR DESCRIPTION
Reverts https://github.com/heroku/heroku-run/commit/5875bc2a6df098d758c734fdc1c788e472321967 and includes logic to fix issues around double quotes in args.