### PR TITLE
show size of one-off dyno

### DIFF
--- a/lib/dyno.js
+++ b/lib/dyno.js
@@ -95,7 +95,7 @@ class Dyno {
   }
 
   _status (status) {
-    return `${status}, ${this.dyno.name || this.opts.dyno}`
+    return `${status}, ${this.dyno.name || this.opts.dyno} (${this.dyno.size})`
   }
 
   _readData (c) {


### PR DESCRIPTION
In Heroku Support, we've seen some confusion when someone has a large web dyno (Standard-2X, Perf-M, etc) and expects a one-off to be this same size. 

In order to make this more clear, this PR adds the size of the dyno that is started.

Previous behavior:

```
Running bash on ⬢ mccartie-node... up, run.3379
```

New behavior:

```
Running bash on ⬢ mccartie-node... up, run.3379 (Standard-1X)
```

And works if you pass in size:

```
$ h run bash -a mccartie-node --size=Standard-2X
Running bash on ⬢ mccartie-node... up, run.8976 (Standard-2X)
```

