### PR TITLE
consistent coloring

### DIFF
--- a/lib/log_displayer.js
+++ b/lib/log_displayer.js
@@ -4,25 +4,30 @@ let cli = require('heroku-cli-util')
 let liner = require('../lib/line_transform')
 
 const COLORS = [
-  s => cli.color.cyan(s),
-  s => cli.color.magenta(s),
   s => cli.color.yellow(s),
   s => cli.color.green(s),
-  s => cli.color.red(s),
+  s => cli.color.cyan(s),
+  s => cli.color.magenta(s),
   s => cli.color.blue(s),
+  s => cli.color.bold.green(s),
   s => cli.color.bold.cyan(s),
   s => cli.color.bold.magenta(s),
   s => cli.color.bold.yellow(s),
-  s => cli.color.bold.green(s),
-  s => cli.color.bold.red(s),
   s => cli.color.bold.blue(s)
 ]
-let assignedColors = {}
+const assignedColors = {}
 function getColorForIdentifier (i) {
   if (assignedColors[i]) return assignedColors[i]
   assignedColors[i] = COLORS[Object.keys(assignedColors).length % COLORS.length]
   return assignedColors[i]
 }
+
+// get initial colors so they are the same every time
+getColorForIdentifier('run')
+getColorForIdentifier('router')
+getColorForIdentifier('web')
+getColorForIdentifier('postgres')
+getColorForIdentifier('heroku-postgres')
 
 let lineRegex = /^(.*?\[([\w-]+)([\d.]+)?]:)(.*)?$/
 function colorize (line) {


### PR DESCRIPTION
today it's random which color is which for `heroku logs` titles, this makes them consistent:

<img width="512" alt="screen_shot_2017-06-06_at_12 17 39_pm_1024" src="https://user-images.githubusercontent.com/216188/26847536-4a22013e-4ab2-11e7-922d-5fe80fe60280.png">
