### PR TITLE
Allow attached dyno to be written to

### DIFF
--- a/lib/dyno.js
+++ b/lib/dyno.js
@@ -5,6 +5,8 @@ let url = require('url')
 let tty = require('tty')
 let stream = require('stream')
 let cli = require('heroku-cli-util')
+let EventEmitter = require('events')
+let util = require('util')
 let helpers = require('../lib/helpers')
 
 const http = require('https')
@@ -77,27 +79,34 @@ class Dyno {
     }
   }
 
+  write (data) {
+    // Rendezvous only
+    if (this._connection && typeof this._connection.write === 'function') {
+      return this._connection.write(data)
+    }
+  }
+
   _rendezvous () {
     return new Promise((resolve, reject) => {
       this.resolve = resolve
       this.reject = reject
 
       if (this.opts.showStatus) cli.action.status(this._status('starting'))
-      let c = tls.connect(this.uri.port, this.uri.hostname, {rejectUnauthorized: this.heroku.options.rejectUnauthorized})
-      c.setTimeout(1000 * 60 * 20)
-      c.setEncoding('utf8')
-      c.on('connect', () => {
-        c.write(this.uri.path.substr(1) + '\r\n', () => {
+      this._connection = tls.connect(this.uri.port, this.uri.hostname, {rejectUnauthorized: this.heroku.options.rejectUnauthorized})
+      this._connection.setTimeout(1000 * 60 * 20)
+      this._connection.setEncoding('utf8')
+      this._connection.on('connect', () => {
+        this.write(this.uri.path.substr(1) + '\r\n', () => {
           if (this.opts.showStatus) cli.action.status(this._status('connecting'))
         })
       })
-      c.on('data', this._readData(c))
-      c.on('close', () => {
+      this._connection.on('data', this._readData(this._connection))
+      this._connection.on('close', () => {
         this.opts['exit-code'] ? this.reject('No exit code returned') : this.resolve()
         if (this.unpipeStdin) this.unpipeStdin()
       })
-      c.on('error', this.reject)
-      process.once('SIGINT', () => c.end())
+      this._connection.on('error', this.reject)
+      process.once('SIGINT', () => this._connection.end())
     })
   }
 
@@ -210,6 +219,7 @@ class Dyno {
         return
       }
       process.stdout.write(data)
+      this.emit('data', data)
     }
   }
 
@@ -238,5 +248,7 @@ class Dyno {
     }
   }
 }
+
+util.inherits(Dyno, EventEmitter)
 
 module.exports = Dyno


### PR DESCRIPTION
1. Expose `data` event so client knows when the dyno is live
2. Expose a new `Dyno#write` method which proxies to the connection

This is relevant to some work we need to do in `heroku-ci` for the `debug` command. There, we'll stop creating the Dyno from the command itself, but rather letting the test-run to start the one off. By doing that, we're losing the ability to write any command users would want to write to.

Thanks to this PR, we'll still provide the same functionality to users unlocking some other internal work we need to accomplish for Heroku CI. Please, reach out to @heroku/devex in case of you're curious to hear more details.

cc @appleton 