### PR TITLE
Pass type parameter

### DIFF
--- a/commands/detached.js
+++ b/commands/detached.js
@@ -12,6 +12,7 @@ function * run (context, heroku) {
     app: context.app,
     command: helpers.buildCommand(context.args),
     size: context.flags.size,
+    type: context.flags.type,
     env: context.flags.env,
     attach: false
   }
@@ -46,6 +47,7 @@ module.exports = {
   flags: [
     {name: 'size', char: 's', description: 'dyno size', hasValue: true},
     {name: 'tail', char: 't', description: 'stream logs from the dyno'},
+    {name: 'type', description: 'process type', hasValue: true},
     {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true}
   ],
   run: cli.command(co.wrap(run))

--- a/commands/run.js
+++ b/commands/run.js
@@ -11,6 +11,7 @@ function * run (context, heroku) {
     app: context.app,
     command: helpers.buildCommand(context.args),
     size: context.flags.size,
+    type: context.flags.type,
     'exit-code': context.flags['exit-code'],
     env: context.flags.env,
     'no-tty': context.flags['no-tty'],
@@ -45,6 +46,7 @@ module.exports = {
   needsApp: true,
   flags: [
     {name: 'size', char: 's', description: 'dyno size', hasValue: true},
+    {name: 'type', description: 'process type', hasValue: true},
     {name: 'exit-code', char: 'x', description: 'passthrough the exit code of the remote command'},
     {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
     {name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false},

--- a/lib/dyno.js
+++ b/lib/dyno.js
@@ -21,6 +21,7 @@ class Dyno extends Duplex {
    * @param {string} options.app - app to run dyno on
    * @param {string} options.attach - attach to dyno
    * @param {string} options.size - size of dyno to create
+   * @param {string} options.type - type of dyno to create
    * @param {boolean} options.no-tty - force not to use a tty
    * @param {Object} options.env - dyno environment variables
   */
@@ -46,6 +47,7 @@ class Dyno extends Duplex {
         command: command,
         attach: this.opts.attach,
         size: this.opts.size,
+        type: this.opts.type,
         env: this._env(),
         force_no_tty: this.opts['no-tty']
       }


### PR DESCRIPTION
For our container runtime, process types may reference different Docker images. Users need to be able to specify what image to use when booting a one-off dyno.