### PR TITLE
reduce dogwood ssh polling time

### DIFF
--- a/lib/dyno.js
+++ b/lib/dyno.js
@@ -117,7 +117,7 @@ class Dyno extends Duplex {
   }
 
   _ssh () {
-    const interval = 30 * 1000
+    const interval = 1000
     const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
     return this.heroku.get(`/apps/${this.opts.app}/dynos/${this.opts.dyno}`)


### PR DESCRIPTION
On Friday, @ricardochimal commented (https://github.com/heroku/dogwood/issues/678#issuecomment-352146036) that the cli plugin only polls every 30s for dyno status when waiting for an attached dyno.

I did some testing locally, using `heroku plugins:link` and two patches to the `heroku-run` plugin (https://gist.github.com/tcrayford/7efe985c950fd6abd61b5cd07bdef9b2#file-heroku-run-diff):

First, I added a patch using `console.time` to check how long it took to run a oneoff dyno under a dogwood app `shogun-tcrayford-private`, in `run_without_tuning.log`: https://gist.github.com/tcrayford/7efe985c950fd6abd61b5cd07bdef9b2#file-run_without_tuning-log

Then I tuned the interval there down to 1 second and ran again: https://gist.github.com/tcrayford/7efe985c950fd6abd61b5cd07bdef9b2#file-run_with_tuning-log

Just for comparison, here's timing for the same thing (no tuning) on a cedar app: https://gist.github.com/tcrayford/7efe985c950fd6abd61b5cd07bdef9b2#file-run_cedar-log

I did some (very basic) analysis in the shell:

```bash
cat run_with_tuning.log  | cut -f 2 -d ' ' | sed -e 's/ms//g' | ruby -e 'times = STDIN.read.split("\n").map(&:to_i); sum = times.inject(0, &:+); puts "sum=#{sum} avg=#{sum.to_f/times.size.to_f}"'
sum=342462 avg=34246.2

cat run_without_tuning.log  | cut -f 2 -d ' ' | sed -e 's/ms//g' | ruby -e 'times = STDIN.read.split("\n").map(&:to_i); sum = times.inject(0, &:+); puts "sum=#{sum} avg=#{sum.to_f/times.size.to_f}"'
sum=694115 avg=63101.36363636364

$ cat run_cedar.log  | cut -f 2 -d ' ' | sed -e 's/ms//g' | ruby -e 'times = STDIN.read.split("\n").map(&:to_i); sum = times.inject(0, &:+); puts "sum=#{sum} avg=#{sum.to_f/times.size.to_f}"'
sum=116560 avg=11656.0
```

It seems to me that reducing this polling time would notably improve oneoff dyno boot speeds for our customers, at least for those with slack pools (by around 30s in my app's case).